### PR TITLE
Fix project db retrieval and optional file copy

### DIFF
--- a/logic/controller/project.py
+++ b/logic/controller/project.py
@@ -101,7 +101,7 @@ class ProjectController:
             project_id: Id of the project from which files are to be deleted
             db_session: DB Session
         """
-        project = ProjectStoreDB.get_project(db_session, project_id)
+        project = ProjectStoreDB.get_project(project_id, db_session)
 
         for file in files:
             ProjectController.delete_table(file.file_name, project.project_db_name)
@@ -135,7 +135,7 @@ class ProjectController:
             project_id: ID of the project to be deleted
             db_session: Session of the database
         """
-        project = ProjectStoreDB.get_project(db_session, project_id)
+        project = ProjectStoreDB.get_project(project_id, db_session)
 
         EngineDB.delete_db(
             f"{project.project_db_name}.db",

--- a/logic/workspace_management/file_manager.py
+++ b/logic/workspace_management/file_manager.py
@@ -8,7 +8,7 @@ from logic.constants import WorkspaceFolders, FileTransferResults
 
 class FileManager:
     @staticmethod
-    def copy_file(source_file_path: str, project_id) -> str | None:
+    def copy_file(source_file_path: str, project_id=None) -> str | None:
         """
         Copy a file to the StreamQL workspace.
 


### PR DESCRIPTION
## Summary
- fix parameter order when retrieving projects for delete and remove operations
- allow FileManager.copy_file to be called without project_id

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b97e6130483268da3d4473ceafca8