### PR TITLE
Fix workspace paths and improve API session handling

### DIFF
--- a/logic/controller/file.py
+++ b/logic/controller/file.py
@@ -82,8 +82,7 @@ class FileController:
         return added_files
 
     @staticmethod
-    def delete_files(file_ids: list[UUID]):
-        session = workspace.get_db_session()
+    def delete_files(file_ids: list[UUID], session: Session):
         for file_id in file_ids:
             # Check if file is linked to any project
             file_links = (
@@ -94,7 +93,7 @@ class FileController:
             FileStoreDB.delete_file(session=session, file_id=file_id)
 
     @staticmethod
-    def update_files(source_file_path: str, file_id: UUID, session: Session = None):
+    def update_files(source_file_path: str, file_id: UUID, session: Session):
         file_obj = FileStoreDB.get_file(session, file_id)
         links = session.query(ProjectFileLinkDB).filter_by(file_id=file_id).all()
 

--- a/logic/controller/project.py
+++ b/logic/controller/project.py
@@ -26,7 +26,7 @@ class ProjectController:
         EngineDB.execute_query(
             sql_query=f"DROP TABLE IF EXISTS '{table_name}'",
             db_name=db_file,
-            workspace_path=str(workspace.get_path(WorkspaceFolders.USER_FILES)),
+            workspace_path=str(workspace.get_path(WorkspaceFolders.PROJECTS)),
             fetch=False,
         )
 
@@ -40,9 +40,8 @@ class ProjectController:
             table_data: Data to be inseted in the newly created table
         """
         db_file = f"{db_id}.db"
-        db_path = workspace.get_path(WorkspaceFolders.USER_FILES) / db_file
         conn = EngineDB.create_db(
-            db_file, str(workspace.get_path(WorkspaceFolders.USER_FILES))
+            db_file, str(workspace.get_path(WorkspaceFolders.PROJECTS))
         )
         table_data.to_sql(table_name, conn, index=False, if_exists="replace")
         conn.close()
@@ -83,7 +82,6 @@ class ProjectController:
         """
         project = ProjectStoreDB.get_project(project_id, db_session)
         db_file = f"{project.project_db_name}.db"
-        db_path = str(workspace.get_path(WorkspaceFolders.USER_FILES))
 
         for file in files:
             df = pd.read_csv(file.file_path)
@@ -139,7 +137,7 @@ class ProjectController:
 
         EngineDB.delete_db(
             f"{project.project_db_name}.db",
-            str(workspace.get_path(WorkspaceFolders.USER_FILES)),
+            str(workspace.get_path(WorkspaceFolders.PROJECTS)),
         )
         ProjectStoreDB.delete_project(db_session, project_id)
 
@@ -177,7 +175,7 @@ class ProjectController:
         try:
             project = ProjectStoreDB.get_project(project_id, db_session)
             db_file = f"{project.project_db_name}.db"
-            db_path = str(workspace.get_path(WorkspaceFolders.USER_FILES))
+            db_path = str(workspace.get_path(WorkspaceFolders.PROJECTS))
 
             result = EngineDB.execute_query(
                 sql_query=sql_query,

--- a/logic/routers/file.py
+++ b/logic/routers/file.py
@@ -33,9 +33,9 @@ async def get_files(
 
 
 @router.delete("/")
-async def delete_files(request: FileDeleteRequest):
+async def delete_files(request: FileDeleteRequest, db: Session = Depends(sqldb.get_db)):
     try:
-        FileController.delete_files(request.file_ids)
+        FileController.delete_files(request.file_ids, db)
         return {"status": "success", "message": "Files deleted"}
     except Warning as w:
         raise HTTPException(status_code=400, detail=str(w))

--- a/logic/workspace_management/file_manager.py
+++ b/logic/workspace_management/file_manager.py
@@ -1,5 +1,4 @@
 import shutil
-import os
 from pathlib import Path
 
 from logic.workspace_management.workspace import workspace
@@ -65,10 +64,14 @@ class FileManager:
             FileTransferResults indicating success or failure.
         """
         try:
-            df = pd.read_csv(file_path, nrows=5)
-            return not df.empty and len(df.columns) > 0
-        except Exception:
-            return False
+            destination_dir = workspace.get_path(WorkspaceFolders.USER_FILES)
+            Path(destination_dir).mkdir(parents=True, exist_ok=True)
+            destination_path = Path(destination_dir) / file_id
+            shutil.copy(new_file_path, destination_path)
+            return FileTransferResults.COPY_SUCCESS
+        except Exception as e:
+            print(f"Error updating file: {e}")
+            return FileTransferResults.COPY_FAILED
 
     @staticmethod
     def get_file(file_id: str) -> Path | None:

--- a/logic/workspace_management/workspace.py
+++ b/logic/workspace_management/workspace.py
@@ -3,19 +3,24 @@ from logic.constants import WorkspaceFolders
 
 
 class Workspace:
-    def __init__(self, username=Path.home().name):
-        self.workspace_path = Path(f"/Users/{username}/streamql")
-        self.paths = {}
+    def __init__(self, base_dir: Path | None = None):
+        """Container for all files created by StreamQL.
+
+        Parameters
+        ----------
+        base_dir: optional :class:`~pathlib.Path`
+            Base directory for the workspace.  Defaults to ``~/streamql``.
+        """
+        self.workspace_path = base_dir or (Path.home() / "streamql")
+        self.paths: dict[str, Path] = {}
 
     def create_workspace(self):
-        """
-        Creates all the necessary directories to run the application
-        """
-        self.workspace_path.mkdir(exist_ok=True)
+        """Create the directory tree used by the application."""
+        self.workspace_path.mkdir(parents=True, exist_ok=True)
 
         for folder in WorkspaceFolders:
             folder_path = self.workspace_path / folder.value
-            folder_path.mkdir(exist_ok=True)
+            folder_path.mkdir(parents=True, exist_ok=True)
             self.paths[folder.name.lower()] = folder_path
 
     def get_path(self, folder: WorkspaceFolders) -> Path:

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,28 @@
+# StreamQL
+
+Simple FastAPI backend with a React frontend for managing projects and running SQL queries against imported CSV files.
+
+## Backend
+
+The backend requires Python 3.10+.
+
+Install dependencies and run the API:
+
+```bash
+pip install -r requirements.txt
+uvicorn logic.app:app --reload
+```
+
+The first run will create a `~/streamql` workspace containing databases and uploaded files.
+
+## Frontend
+
+The React frontend lives in the `ui` folder and uses Vite.
+
+```bash
+cd ui
+npm install
+npm run dev
+```
+
+This will start the development server on port 5173.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+sqlalchemy
+pandas


### PR DESCRIPTION
## Summary
- store the application workspace under `~/streamql`
- copy/update files in the workspace correctly
- require DB session when deleting/updating files
- keep project databases inside the projects folder
- document how to run the app locally
- add a simple `requirements.txt`

## Testing
- `pip install fastapi sqlalchemy pandas uvicorn --quiet`
- `pip check`
- `python -m compileall -q logic engine`

------
https://chatgpt.com/codex/tasks/task_e_688b985b154c8326ad0e97b3ce12e6da